### PR TITLE
Improve check setup

### DIFF
--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -16,7 +16,7 @@ jobs:
           init-shell: bash
       - name: Run check
         run: |
-          python check-setup.py
+          python check-setup.py --strict
       - name: Run notebooks
         shell: bash -el {0}
         run: |

--- a/.github/workflows/ci-conda.yml
+++ b/.github/workflows/ci-conda.yml
@@ -15,6 +15,7 @@ jobs:
           environment-file: environment.yaml
           init-shell: bash
       - name: Run check
+        shell: bash -el {0}
         run: |
           python check-setup.py --strict
       - name: Run notebooks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           pip install -r requirements.txt
       - name: Run check
         run: |
-          python check-setup.py
+          python check-setup.py --strict
       - name: Run notebooks
         run: |
           jupyter nbconvert --execute --to html notebooks/*.ipynb

--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ To execute the notebooks and examples from this tutorial, you are expected to ha
 
 ```bash
 git clone https://github.com/adonath/scipy-2023-pydantic-tutorial
+
 ```
+:warning: **Note:** If you have cloned the repository before July 10, 2023, please make sure to update it to the latest version following the [instructions below](#updating-the-repository).
+
+
 And change to the cloned folder:
 
 ```bash
@@ -57,9 +61,29 @@ To execute the notebooks along with the presentation, start the Jupyter server:
 jupyter notebook
 ```
 
+### Updating the repository
+
+If you have cloned the repository before July 10, 2023, please make sure to update it to the latest version.
+In case you have local changes, we would recommend to store those in a separate branch before updating the repository. To do so, change to the cloned folder and execute the following commands:
+
+```bash
+git checkout -b my-local-changes
+git add .
+git commit -m "My local changes"
+```
+
+Then you can update the repository using:
+
+```bash
+git checkout main
+git pull origin main
+```
+
+Now you should have the latest version of the repository.
+
+
 ## Binder 
-If you don not have a working installation (for whatever reason) until the tutorial starts, you can also execute the tutorial in the browser using Binder.
-Just click on the following badge to start the Binder service:
+If you don not have a working installation (for whatever reason) until the tutorial starts, you can also execute the tutorial in the browser using Binder. Just click on the following badge to start the Binder service:
 
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/adonath/scipy-2023-pydantic-tutorial/HEAD)
 


### PR DESCRIPTION
This PR improves the `check-setup.py` script, based on a comment received by a participant. The `check-setup.py`, failed incorrectly because of the missing `pre-commit` dependency, which is not need and the incorrect parsing of the Pydantic requirement. I fixed both errors in this PR and added a `--strict` option to run the check in the CI, such that any issue will be noticed. I also added instructions on how to update the repository, if it has been cloned before the tutorial.