### PR TITLE
Remove static type check duplication from introduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 __pycache__/
 .mypy_cache
 .ipynb_checkpoints
-notebooks/my_script.py
+notebooks/my-script.py

--- a/notebooks/1-introduction-and-refreshers.ipynb
+++ b/notebooks/1-introduction-and-refreshers.ipynb
@@ -104,17 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Python will \"happily\" execute the calls to `my_function`, but the result is possibly un-expected. In contrast the call to `my_other_function` fails. The reason is that the `*` operator is overloaded for strings / bools and integers, but not for strings and floats. This behaviou is built into the Python language and can not be changed. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "value = \"hello\"\n",
-    "type(value)"
+    "Python will \"happily\" execute the calls to `my_function`, but the result is possibly un-expected. In contrast the call to `my_other_function` fails. The reason is that the `*` operator is overloaded for strings / bools and integers, but not for strings and floats. This behaviour is built into the Python language and cannot really be changed. "
    ]
   },
   {
@@ -212,69 +202,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Refresher 1: Type Annotations\n",
-    "\n",
-    "Python 3 introduced type annotations as a way to document the expected types of variables, function arguments, and return values. Type annotations are **not enforced by the Python interpreter**, but can be used by external tools to perform static code analysis. The most popular tool for this purpose is [mypy](http://mypy-lang.org/).\n",
-    "\n",
-    "Quick survey:\n",
-    "- Who knows what type annotations are?\n",
-    "- Who is using type annotations regularly?\n",
-    "- Who would like to use type annotations more, but is not doing it yet?\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%writefile my_script.py\n",
-    "def my_function(x: int) -> int:\n",
-    "    return 2 * x\n",
-    "\n",
-    "\n",
-    "def my_other_function(x: float) -> float:\n",
-    "    return 2.0 * x\n",
-    "\n",
-    "\n",
-    "print(my_function(3))\n",
-    "print(my_function(3.14))\n",
-    "\n",
-    "print(my_other_function(\"hello\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!cat my_script.py"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!mypy my_script.py"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Refresher 2: Class Definitions\n",
-    "\n",
-    "Recall that classes in Python are defined with the `class` keyword followed by the name of the class (usually capitalized) and a colon. Class and instance methods are defined inside the class by indenting once. Let's create a simple class to represent a two dimensional point coordinate. I will add \"V1\" to the end of the class name so that we can make improvements later (\"V2\", \"V3\", etc.) and compare versions.\n",
     "\n",
     "Quick survey:\n",
     "- Who knows what class definitions are?\n",
     "- Who is using class definitions regularly?\n",
-    "- Who would like to use class definitons more, but is not doing it yet?"
+    "- Who would like to use class definitons more, but is not doing it yet?\n",
+    "\n",
+    "\n",
+    "Recall that classes in Python are defined with the `class` keyword followed by the name of the class (usually capitalized) and a colon. Class and instance methods are defined inside the class by indenting once. Let's create a simple class to represent a two dimensional point coordinate. We will add \"V1\" to the end of the class name so that we can make improvements later (\"V2\", \"V3\", etc.) and compare versions."
    ]
   },
   {
@@ -347,9 +283,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "but it would be nice if your code editor (IDE) could highlight this mistake for you before even executing a single line of code.\n",
+    "But it would be nice if your code editor (IDE) could highlight this mistake for you before even executing a single line of code."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Refresher 2: Type Annotations\n",
     "\n",
-    "Introduced in Python 3.5, [type annotations](https://docs.python.org/3/library/typing.html) (also known as type hints) provide a mechanism to solve both problems simultaneously. Intended types can be supplied after an argument or variable by separating the two with a colon. And output types can by supplied after the closing parenthesis and before the colon with an arrow `->`. Let's improve the `PointV1` class with type annotations."
+    "Introduced in Python 3.5, [type annotations](https://docs.python.org/3/library/typing.html) (also known as type hints) provide a mechanism to solve both problems simultaneously. \n",
+    "\n",
+    "Quick survey:\n",
+    "- Who knows what type annotations are?\n",
+    "- Who is using type annotations regularly?\n",
+    "- Who would like to use type annotations more, but is not doing it yet?\n",
+    "\n",
+    "Intended types can be supplied after an argument or variable by separating the two with a colon. And output types can by supplied after the closing parenthesis and before the colon with an arrow `->`. Let's improve the `PointV1` class with type annotations."
    ]
   },
   {
@@ -390,7 +341,41 @@
     "\n",
     "![image-4.png](attachment:image-4.png)\n",
     "\n",
-    "Notice the yellow squiggly lines under `x=\"5\"` and `y=\"7\"` in the creation of `p1` and the lack of yellow squiggly lines under `x=-1` and `y=4` in the creation of `p2`."
+    "Notice the orange squiggly lines under `x=\"5\"` and `y=\"7\"` in the creation of `p1` and the lack of yellow squiggly lines under `x=-1` and `y=4` in the creation of `p2`."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also use a tool such as [mypy](https://mypy-lang.org) to check the types of your code. Let's check the code in the example `my-script.py`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat my-script.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mypy my-script.py"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However it is important to repeat that type annotations are not enforced by the Python interpreter, but are typically only  used by external tools to perform static code analysis."
    ]
   },
   {
@@ -503,6 +488,14 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another variation is to use a `TypedDict` to define a class with a fixed set of attributes:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -538,7 +531,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And the types are not enforced during runtime, such that they can be changed anytime later:"
+    "And as with the other classes, the types are not enforced during runtime, such that they can be changed anytime later:"
    ]
   },
   {
@@ -555,7 +548,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `TypedDict` is agian mostly useful for static code analysis, in which case the statement above would be highlighted as an error. \n",
+    "The `TypedDict` is again mostly useful for static code analysis, in which case the statement above would be highlighted as an error. \n",
     "\n",
     "All these limitations and issues listed above can be addressed with the [pydantic](https://pydantic-docs.helpmanual.io/) library. This library allows to define data classes with type annotations and to validate the input data against the type annotations.\n",
     "\n",
@@ -564,12 +557,6 @@
     "- Just take some to briefly discuss with your neighbours the examples where dynamic typing leads to unexpected behaviour. Have you encountered similar issues in the past? How did you solve them? \n",
     "- Also take some time to dicuss the concepts of type annotations, class definitions and data classes we reviewed above. Have you used them in the past? What are your experiences? "
    ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/my-script.py
+++ b/notebooks/my-script.py
@@ -1,0 +1,17 @@
+class PointV2:
+    """Representation of a two-dimensional point coordinate."""
+
+    def __init__(self, x: float, y: float) -> None:
+        """Initializes a PointV2 with the given coordinates."""
+        self.x = x
+        self.y = y
+
+    def distance_to(self, other: "PointV2") -> float:
+        """Computes the distance to another `PointV2`."""
+        dx = self.x - other.x
+        dy = self.y - other.y
+        return (dx**2 + dy**2) ** 0.5
+
+
+p1 = PointV2(x="5", y="7")
+p2 = PointV2(x=5, y=7)


### PR DESCRIPTION
There was some duplication of demonstrating the the static type checking in the introduction, which resulted from merging the content. This is addressed in this PR.